### PR TITLE
fix: allow transaction to go through even if confirmation mail fails

### DIFF
--- a/src/components/CheckoutModal.vue
+++ b/src/components/CheckoutModal.vue
@@ -53,7 +53,7 @@
                 {{ t('gift.amount_gifted') }} : {{ props.amountGifted }}
                 {{ settingsStore.currency }}
               </div>
-              <div class="mt-6 border-t border-gray-200 pt-6">
+              <div class="mt-6 border-t border-gray-200 pt-6" v-if="selectedPaymentMethod">
                 <fieldset>
                   <legend class="text-lg font-medium text-gray-900">
                     {{ t('checkout.modal_payment') }}
@@ -92,7 +92,7 @@
                   </RadioGroup>
                 </fieldset>
               </div>
-              <div class="text-sm text-gray-700 mt-2">
+              <div class="text-sm text-gray-700 mt-2" v-if="selectedPaymentMethod">
                 <div class="flex flex-col align-middle">
                   <div
                     class="flex justify-center my-1"

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -93,22 +93,32 @@ export const useCartStore = defineStore('cart', () => {
         purchaser.country,
     }
 
-    const res = await emailjs.send(
-      'contact_katjafrancesco',
-      'gift_confirmation_' + locale,
-      {
-        first_name: purchaser.name,
-        last_name: purchaser.surname,
-        to_email: purchaser.email,
-        amount_gifted: total(),
-      },
-      { publicKey: import.meta.env.VITE_EMAILJS_PK }
-    )
-
-    if (res.status !== 200) {
-      console.error(res)
-      return false
-    }
+    emailjs
+      .send(
+        'contact_katjafrancesco',
+        'gift_confirmation_' + locale,
+        {
+          first_name: purchaser.name,
+          last_name: purchaser.surname,
+          to_email: purchaser.email,
+          amount_gifted: total(),
+        },
+        { publicKey: import.meta.env.VITE_EMAILJS_PK }
+      )
+      .catch((err) => {
+        console.error('EmailJS error:', err)
+        emailjs.send(
+          'contact_katjafrancesco',
+          'registry_checkout_error',
+          {
+            full_name: purchaser.name + ' ' + purchaser.surname,
+            amount_gifted: total(),
+            to_email: purchaser.email,
+            error: err.message,
+          },
+          { publicKey: import.meta.env.VITE_EMAILJS_PK }
+        )
+      })
 
     const donor_res = await supabase.from('donors').insert(donor).select('id').single()
 


### PR DESCRIPTION
If the confirmation email cannot be sent the transaction will go through and another email is sent to the admin. If no payment method is defined, the div is not rendered altogether to avoid null errors